### PR TITLE
feat: add `binaryType` parameter to WebSocket class

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ socket.message.listen((message) {
 });
 ```
 
+## Protobuf 💬
+
+If you're using `web_socket_client` on the web with Protobuf, you might
+want to use `binaryType` when initializing the `WebSocket` class. It is not
+necessary when using it for dekstop or mobile devices:
+
+```dart
+final socket = WebSocket(Uri.parse('ws://localhost:8080'), binaryType: 'arraybuffer');
+```
+
 ## Closing the Connection 🚫
 
 Once a `WebSocket` connection is established, it will automatically attempt to

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ increasing amount of time until a maximum step is reached.
 // Initially wait 1s and double the wait time until a maximum step of of 3 is reached.
 // [1, 2, 4, 4, 4, ...]
 const backoff = BinaryExponentialBackoff(
-  initial: Duration(seconds: 1),  
+  initial: Duration(seconds: 1),
   maximumStep: 3
 );
 final socket = WebSocket(uri, backoff: backoff);
@@ -124,7 +124,7 @@ The connection state can be one of the following:
 - **disconnected**: the WebSocket connection has been closed or could not be
   established.
 
-_* The disconnected connection state contains nullable fields for the close
+_\* The disconnected connection state contains nullable fields for the close
 code, close reason, error, and stack trace._
 
 ## Sending Messages 📤
@@ -158,8 +158,8 @@ socket.message.listen((message) {
 ## Protobuf 💬
 
 If you're using `web_socket_client` on the web with Protobuf, you might
-want to use `binaryType` when initializing the `WebSocket` class. It is not
-necessary when using it for dekstop or mobile devices:
+want to use `binaryType` when initializing the `WebSocket` class.
+`binaryType` is only applicable on the web and is not used on desktop or mobile platforms.
 
 ```dart
 final socket = WebSocket(Uri.parse('ws://localhost:8080'), binaryType: 'arraybuffer');

--- a/lib/src/_web_socket_connect/_web_socket_connect.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect.dart
@@ -3,6 +3,7 @@ Future<Stream<dynamic>> connect(
   String url, {
   Iterable<String>? protocols,
   Duration? pingInterval,
+  String? binaryType,
 }) {
   throw UnsupportedError('No implementation of the api provided');
 }

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -6,8 +6,11 @@ Future<WebSocket> connect(
   String url, {
   Iterable<String>? protocols,
   Duration? pingInterval,
+  String? binaryType,
 }) async {
   final socket = WebSocket(url, protocols);
+  socket.binaryType = binaryType;
+
   if (socket.readyState == 1) return socket;
 
   final completer = Completer<WebSocket>();

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -8,8 +8,7 @@ Future<WebSocket> connect(
   Duration? pingInterval,
   String? binaryType,
 }) async {
-  final socket = WebSocket(url, protocols);
-  socket.binaryType = binaryType;
+  final socket = WebSocket(url, protocols)..binaryType = binaryType;
 
   if (socket.readyState == 1) return socket;
 

--- a/lib/src/_web_socket_connect/_web_socket_connect_io.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_io.dart
@@ -5,6 +5,7 @@ Future<WebSocket> connect(
   String url, {
   Iterable<String>? protocols,
   Duration? pingInterval,
+  String? binaryType,
 }) async {
   return await WebSocket.connect(url, protocols: protocols)
     ..pingInterval = pingInterval;

--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -30,11 +30,13 @@ class WebSocket {
     Duration? pingInterval,
     Backoff? backoff,
     Duration? timeout,
+    String? binaryType,
   })  : _uri = uri,
         _protocols = protocols,
         _pingInterval = pingInterval,
         _backoff = backoff ?? _defaultBackoff,
-        _timeout = timeout ?? _defaultTimeout {
+        _timeout = timeout ?? _defaultTimeout,
+        _binaryType = binaryType {
     _connect();
   }
 
@@ -43,6 +45,7 @@ class WebSocket {
   final Duration? _pingInterval;
   final Backoff _backoff;
   final Duration _timeout;
+  final String? _binaryType;
 
   final _messageController = StreamController<dynamic>.broadcast();
   final _connectionController = ConnectionController();
@@ -90,6 +93,7 @@ class WebSocket {
         _uri.toString(),
         protocols: _protocols,
         pingInterval: _pingInterval,
+        binaryType: _binaryType,
       ).timeout(_timeout);
 
       final connectionState = _connectionController.state;


### PR DESCRIPTION
## Status
**DONE**

## Description
Greetings,
I really like this project. It's just so simple to use and painless. That's why I'm thanking you for your time taken to maintain the project. Unfortunately it wasn't working on Flutter for the Web, as I was using Protobuf and consequently ran into issues with JavaScript Blob to List<int> (bytearray) conversion. This fix adds another parameter to the class, which [is ran](https://api.dart.dev/stable/2.19.3/dart-html/WebSocket-class.html) by the `dart:html` WebSocket class and with the help of it, I'm able to set the `binaryType` to `arraybuffer`, per [this source](https://stackoverflow.com/questions/18578539/convert-blob-to-listint) and it successfully works with Protobuf.

Before adding the flag/parameter
![image](https://user-images.githubusercontent.com/52399966/222928154-32b99fa2-038f-40f8-8188-a88f8e7b508f.png)

After adding the flag and setting it to `arraybuffer`
![image](https://user-images.githubusercontent.com/52399966/222928106-d5290af5-15e5-441c-bd21-d45d74fa2711.png)


## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
