### PR TITLE
fix: remove `Disconnecting` state from `_isConnected`.

### DIFF
--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -56,9 +56,7 @@ class WebSocket {
 
   bool get _isConnected {
     final connectionState = _connectionController.state;
-    return connectionState is Connected ||
-        connectionState is Reconnected ||
-        connectionState is Disconnecting;
+    return connectionState is Connected || connectionState is Reconnected;
   }
 
   bool get _isReconnecting {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**DONE**

## Description

The `_isConnected` in `WebSocket` including `Disconnecting` state, which is not belong to isConnected condition, should be removed. 

To be: 

```dart
  bool get _isConnected {
    final connectionState = _connectionController.state;
    return connectionState is Connected || connectionState is Reconnected;
  }
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
