### PR TITLE
feat: add message queue to `WebSocket` class

### DIFF
--- a/test/src/web_socket_client_test.dart
+++ b/test/src/web_socket_client_test.dart
@@ -230,6 +230,8 @@ void main() {
           ]),
         );
 
+        await Future<void>.delayed(Duration.zero);
+
         expect(messages, equals(['ping', 'pong']));
 
         socket.close();


### PR DESCRIPTION
## WebSocket Client - Message Queue Feature

This pull request adds a message queue feature to the `WebSocket` class to handle message queuing and ensure messages are sent in the correct order when the WebSocket connection is not yet established. The message queue stores messages that need to be transmitted to the server over the WebSocket connection until the connection is ready.

### Changes Made

- Added a new private list `_messageQueue` to store enqueued messages.
- Modified the `send` method to enqueue messages when the WebSocket is not connected and send them immediately when the WebSocket is connected.
- Created a new private method `_sendQueuedMessages` to process and send messages from the queue when the WebSocket is connected.
- Modified the `_connect` method to call `_sendQueuedMessages` after establishing the WebSocket connection to send any enqueued messages.

### Reasoning

The addition of the message queue ensures that messages are sent in the order they were queued once the WebSocket connection is established. This improves the reliability and consistency of the WebSocket client, preventing potential issues with message order and avoiding unresponsive behavior when sending messages before the connection is ready.

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
