### PR TITLE
feat: add httpClient parameter to WebSocket class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 build/
 pubspec.lock
 coverage/
+
+.idea/
+*.iml

--- a/lib/src/_web_socket_connect/_web_socket_connect.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 /// Create a WebSocket connection.
 Future<Stream<dynamic>> connect(
   String url, {
   Iterable<String>? protocols,
   Duration? pingInterval,
   String? binaryType,
+  HttpClient? httpClient,
 }) {
   throw UnsupportedError('No implementation of the api provided');
 }

--- a/lib/src/_web_socket_connect/_web_socket_connect_io.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_io.dart
@@ -6,7 +6,11 @@ Future<WebSocket> connect(
   Iterable<String>? protocols,
   Duration? pingInterval,
   String? binaryType,
+  HttpClient? httpClient,
 }) async {
-  return await WebSocket.connect(url, protocols: protocols)
-    ..pingInterval = pingInterval;
+  return await WebSocket.connect(
+    url,
+    protocols: protocols,
+    customClient: httpClient,
+  )..pingInterval = pingInterval;
 }

--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_socket_client/src/_web_socket_channel/_web_socket_channel.dart'
@@ -31,12 +32,14 @@ class WebSocket {
     Backoff? backoff,
     Duration? timeout,
     String? binaryType,
+    HttpClient? httpClient,
   })  : _uri = uri,
         _protocols = protocols,
         _pingInterval = pingInterval,
         _backoff = backoff ?? _defaultBackoff,
         _timeout = timeout ?? _defaultTimeout,
-        _binaryType = binaryType {
+        _binaryType = binaryType,
+        _httpClient = httpClient {
     _connect();
   }
 
@@ -46,6 +49,7 @@ class WebSocket {
   final Backoff _backoff;
   final Duration _timeout;
   final String? _binaryType;
+  final HttpClient? _httpClient;
 
   final _messageController = StreamController<dynamic>.broadcast();
   final _connectionController = ConnectionController();
@@ -94,6 +98,7 @@ class WebSocket {
         protocols: _protocols,
         pingInterval: _pingInterval,
         binaryType: _binaryType,
+        httpClient: _httpClient,
       ).timeout(_timeout);
 
       final connectionState = _connectionController.state;


### PR DESCRIPTION
## Status

**READY**

## Description

Consuming code can now pass in a predefined HttpClient, allowing for customisations such as a SecurityContext with an mTLS client certificate and password.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
