### PR TITLE
fix: migrate to `package:web`

### DIFF
--- a/lib/src/_web_socket_channel/_web_socket_channel_html.dart
+++ b/lib/src/_web_socket_channel/_web_socket_channel_html.dart
@@ -1,9 +1,8 @@
-import 'dart:html' as html;
-
+import 'package:web/web.dart';
 import 'package:web_socket_channel/html.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Get am [HtmlWebSocketChannel] for the provided [socket].
-WebSocketChannel getWebSocketChannel(html.WebSocket socket) {
+WebSocketChannel getWebSocketChannel(WebSocket socket) {
   return HtmlWebSocketChannel(socket);
 }

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -13,7 +13,10 @@ Future<WebSocket> connect(
   final socket = WebSocket(
     url,
     protocols?.map((e) => e.toJS).toList().toJS ?? JSArray(),
-  )..binaryType = binaryType ?? 'list';
+  )
+    // Either "blob" (default) or "arraybuffer".
+    // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType
+    ..binaryType = binaryType ?? 'blob';
 
   if (socket.readyState == 1) return socket;
 

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -3,31 +3,6 @@ import 'dart:js_interop';
 
 import 'package:web/helpers.dart';
 
-// TODO(mytja): remove when https://github.com/dart-lang/web/commit/4cb5811ed06
-// is in a published release and the min constraint on pkg:web is updated
-/// [WebSocketEvents] is an extension to the main [WebSocket] class from
-/// package:web. It adds appropriate streams while https://github.com/dart-lang/web/commit/4cb5811ed06
-/// is not yet published.
-extension WebSocketEvents on WebSocket {
-  /// [onOpen] is a [Stream], which returns [Event]s upon
-  /// establishing new WebSocket connection.
-  Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
-
-  /// [onMessage] is a [Stream], which returns [MessageEvent]s upon
-  /// receiving messages through the WebSocket connection.
-  Stream<MessageEvent> get onMessage =>
-      EventStreamProviders.messageEvent.forTarget(this);
-
-  /// [onClose] is a [Stream], which returns [CloseEvent]s upon
-  /// WebSocket closure.
-  Stream<CloseEvent> get onClose =>
-      EventStreamProviders.closeEvent.forTarget(this);
-
-  /// [onError] is a [Stream], which returns [Event]s upon error.
-  Stream<Event> get onError =>
-      EventStreamProviders.errorEventSourceEvent.forTarget(this);
-}
-
 /// Create a WebSocket connection.
 Future<WebSocket> connect(
   String url, {

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -3,14 +3,27 @@ import 'dart:js_interop';
 
 import 'package:web/helpers.dart';
 
-// TODO: remove when https://github.com/dart-lang/web/commit/4cb5811ed06
+// TODO(mytja): remove when https://github.com/dart-lang/web/commit/4cb5811ed06
 // is in a published release and the min constraint on pkg:web is updated
+/// [WebSocketEvents] is an extension to the main [WebSocket] class from
+/// package:web. It adds appropriate streams while https://github.com/dart-lang/web/commit/4cb5811ed06
+/// is not yet published.
 extension WebSocketEvents on WebSocket {
+  /// [onOpen] is a [Stream], which returns [Event]s upon
+  /// establishing new WebSocket connection.
   Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
+
+  /// [onMessage] is a [Stream], which returns [MessageEvent]s upon
+  /// receiving messages through the WebSocket connection.
   Stream<MessageEvent> get onMessage =>
       EventStreamProviders.messageEvent.forTarget(this);
+
+  /// [onClose] is a [Stream], which returns [CloseEvent]s upon
+  /// WebSocket closure.
   Stream<CloseEvent> get onClose =>
       EventStreamProviders.closeEvent.forTarget(this);
+
+  /// [onError] is a [Stream], which returns [Event]s upon error.
   Stream<Event> get onError =>
       EventStreamProviders.errorEventSourceEvent.forTarget(this);
 }

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -1,5 +1,19 @@
 import 'dart:async';
-import 'dart:html';
+import 'dart:js_interop';
+
+import 'package:web/helpers.dart';
+
+// TODO: remove when https://github.com/dart-lang/web/commit/4cb5811ed06
+// is in a published release and the min constraint on pkg:web is updated
+extension WebSocketEvents on WebSocket {
+  Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
+  Stream<MessageEvent> get onMessage =>
+      EventStreamProviders.messageEvent.forTarget(this);
+  Stream<CloseEvent> get onClose =>
+      EventStreamProviders.closeEvent.forTarget(this);
+  Stream<Event> get onError =>
+      EventStreamProviders.errorEventSourceEvent.forTarget(this);
+}
 
 /// Create a WebSocket connection.
 Future<WebSocket> connect(
@@ -8,7 +22,10 @@ Future<WebSocket> connect(
   Duration? pingInterval,
   String? binaryType,
 }) async {
-  final socket = WebSocket(url, protocols)..binaryType = binaryType;
+  final socket = WebSocket(
+    url,
+    protocols?.map((e) => e.toJS).toList().toJS ?? JSArray(),
+  )..binaryType = binaryType ?? 'list';
 
   if (socket.readyState == 1) return socket;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
+  web: ^0.4.0
   web_socket_channel: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Status

**READY**

## Description

As of version 2.4.1, `package:web_socket_channel` doesn't rely on `dart:html` anymore. Instead, they are using `package:web`, which allows them to add WebAssembly support. As this library relies on `package:web_socket_channel`, their change breaks this library. This PR migrates over to `package:web`, which fixes the library and adds WASM support.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
