### PR TITLE
feat: add `protocol` getter to `WebSocket`

### DIFF
--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -148,9 +148,9 @@ class WebSocket {
 
   /// The subprotocol selected by the server.
   ///
-  /// This is initially empty. After the WebSocket connection is established the
-  /// value is set to the subprotocol selected by the server. If no subprotocol
-  /// is negotiated the value will remain empty.
+  /// This is initially empty. After the connection is established the value is
+  /// set to the subprotocol selected by the server. If no subprotocol is
+  /// negotiated the value will remain empty.
   String get protocol => _channel?.protocol ?? '';
 
   /// Enqueues the specified data to be transmitted

--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -146,13 +146,12 @@ class WebSocket {
   /// The WebSocket [Connection].
   Connection get connection => _connectionController;
 
-  /// The subprotocol used by the connection
+  /// The subprotocol selected by the server.
   ///
-  /// The subprotocol is sent by the server during the initial
-  /// connection handshake, if the client and server aren't
-  /// able to negotiate a protocol during the handshake, it will
-  /// return `null`
-  String? get protocol => _channel?.protocol;
+  /// This is initially empty. After the WebSocket connection is established the
+  /// value is set to the subprotocol selected by the server. If no subprotocol
+  /// is negotiated the value will remain empty.
+  String get protocol => _channel?.protocol ?? '';
 
   /// Enqueues the specified data to be transmitted
   /// to the server over the WebSocket connection.

--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -144,6 +144,14 @@ class WebSocket {
   /// The WebSocket [Connection].
   Connection get connection => _connectionController;
 
+  /// The subprotocol used by the connection
+  ///
+  /// The subprotocol is sent by the server during the initial
+  /// connection handshake, if the client and server aren't
+  /// able to negotiate a protocol during the handshake, it will
+  /// return `null`
+  String? get protocol => _channel?.protocol;
+
   /// Enqueues the specified data to be transmitted
   /// to the server over the WebSocket connection.
   void send(dynamic message) => _channel?.sink.add(message);


### PR DESCRIPTION
## Status

**READY**

## Description

Adds a getter method to `WebSocket` to retrieve the protocol negotiated between the client and server during the handshake. Uses the `_channel` field in `WebSocket` to access the protocol.

Resolves #66

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
