### PR TITLE
feat: Only catch known exceptions

### DIFF
--- a/lib/src/_web_socket_connect/_web_socket_connect.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect.dart
@@ -1,3 +1,7 @@
+
+/// A socket exception for the platform
+typedef PlatformSocketException = Exception;
+
 /// Create a WebSocket connection.
 Future<Stream<dynamic>> connect(
   String url, {

--- a/lib/src/_web_socket_connect/_web_socket_connect_html.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_html.dart
@@ -3,6 +3,9 @@ import 'dart:js_interop';
 
 import 'package:web/web.dart';
 
+/// A socket exception for the platform
+typedef PlatformSocketException = Exception;
+
 /// Create a WebSocket connection.
 Future<WebSocket> connect(
   String url, {

--- a/lib/src/_web_socket_connect/_web_socket_connect_io.dart
+++ b/lib/src/_web_socket_connect/_web_socket_connect_io.dart
@@ -1,5 +1,8 @@
 import 'dart:io';
 
+/// A socket exception for the platform
+typedef PlatformSocketException = SocketException;
+
 /// Create a WebSocket connection.
 Future<WebSocket> connect(
   String url, {

--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -103,6 +103,9 @@ class WebSocket {
     } on TimeoutException catch (error, stackTrace) {
       attemptToReconnect(error, stackTrace);
       return;
+    } on PlatformSocketException catch (error, stackTrace) {
+      attemptToReconnect(error, stackTrace);
+      return;
     }
 
     final connectionState = _connectionController.state;


### PR DESCRIPTION
Only catch known exceptions like timeout. Otherwise something like an invalid uri or an UnsupportedError will enter a endless loop and swallow this issue for the user.
